### PR TITLE
fix: add file extensions to imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,14 @@
   "extends": ["airbnb-base", "prettier"],
   "plugins": ["prettier", "jest"],
   "rules": {
-    "prettier/prettier": "error"
+    "prettier/prettier": "error",
+    "import/extensions": [
+      "error",
+      "ignorePackages",
+      {
+        "js": "always"
+      }
+    ]
   },
   "env": {
     "jest/globals": true

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -2,7 +2,7 @@ import stylelint from 'stylelint';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-import { ruleName } from '../plugin';
+import { ruleName } from '../plugin/index.js';
 
 // eslint-disable-next-line no-underscore-dangle
 const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/borderInBoxModel.js
+++ b/borderInBoxModel.js
@@ -5,7 +5,7 @@
 ==================================================================
 */
 
-import config from './config/extendedStylelintOrderConfig';
+import config from './config/extendedStylelintOrderConfig.js';
 
 const borderInBoxConfig = config({ 'border-in-box-model': true });
 

--- a/config/configCreator.js
+++ b/config/configCreator.js
@@ -1,10 +1,10 @@
-import special from '../groups/special';
-import positioning from '../groups/positioning';
-import boxModel from '../groups/boxModel';
-import typography from '../groups/typography';
-import visual from '../groups/visual';
-import animation from '../groups/animation';
-import misc from '../groups/misc';
+import special from '../groups/special.js';
+import positioning from '../groups/positioning.js';
+import boxModel from '../groups/boxModel.js';
+import typography from '../groups/typography.js';
+import visual from '../groups/visual.js';
+import animation from '../groups/animation.js';
+import misc from '../groups/misc.js';
 
 const configCreator = ({
   'border-in-box-model': borderInBoxModel = false,

--- a/config/extendedStylelintOrderConfig.js
+++ b/config/extendedStylelintOrderConfig.js
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { fileURLToPath } from 'url';
-import specialProps from '../groups/special';
+import specialProps from '../groups/special.js';
 
 // eslint-disable-next-line no-underscore-dangle
 const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/groups/boxModel.js
+++ b/groups/boxModel.js
@@ -1,4 +1,4 @@
-import borderProps from './border';
+import borderProps from './border.js';
 
 const partOne = [
   'display',

--- a/groups/visual.js
+++ b/groups/visual.js
@@ -1,4 +1,4 @@
-import borderProps from './border';
+import borderProps from './border.js';
 
 const partOne = [
   'list-style',

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import config from './config/extendedStylelintOrderConfig';
+import config from './config/extendedStylelintOrderConfig.js';
 
 const defaultConfig = config();
 

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,8 +1,8 @@
 import stylelint from 'stylelint';
 
-import propertiesOrderRule from 'stylelint-order/rules/properties-order';
+import propertiesOrderRule from 'stylelint-order/rules/properties-order/index.js';
 
-import configCreator from '../config/configCreator';
+import configCreator from '../config/configCreator.js';
 
 export const ruleName = 'plugin/rational-order';
 


### PR DESCRIPTION
Привет. У меня возникают проблемы при использовании пакета, ругается:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../node_modules/@sazuru/stylelint-config-rational-order/config/extendedStylelintOrderConfig' imported from .../node_modules/@sazuru/stylelint-config-rational-order/index.js
```
Расширения файлов обязательны при импорте в [ноде](https://arc.net/l/quote/jnxqqgtw)
Добавил везде по проекту расширения файлов и подправил eslint правила.